### PR TITLE
Add <meta> tag to embed tags

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -416,6 +416,7 @@ dom = _.extend(dom,
 
   EMBED_TAGS: {
     'IMG'
+    'META'
   }
 
   LINE_TAGS: {


### PR DESCRIPTION
Since we're going with an approach using `<meta>` tags with pseudo-elements content to display endnotes, we need to have this tag properly configured as an `EMBED_TAG` on the `dom` lib.

I'm still not very fond of this particular change to the lib - putting a `<meta>` tag as an embeddable tag still seems awkward and probably it won't be accepted upstream -, but for now, seems the most simple way to do it. :confused: 

Still going to check if we could have a better approach to support this.
