### PR TITLE
Skip attributes normalisation for void tags

### DIFF
--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -55,7 +55,7 @@ class Normalizer
         value = dom.convertFontSize(value) if attribute == 'size'
         node.style[style] = value
         node.removeAttribute(attribute)
-    )
+    ) if !dom.VOID_TAGS[node.tagName]
     # Chrome turns <b> into style in some cases
     if (node.style.fontWeight == 'bold')
       node.style.fontWeight = ''


### PR DESCRIPTION
Since we are using an `<input>` with the `size` attribute, Quill's normalizer was removing it, because it has a very eager/broad scope for what he thinks are legacy inline font style attributes of other tags (`size`, `face` and `color`).

So, I've looked into the void tags and none of these have those attributes for font style purposes on HTML spec, therefore I changed it to skip attributes normalization on void tags.
