### PR TITLE
npm install best practice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,14 @@ jobs:
         node-version: '10.x'
         registry-url: 'https://npm.pkg.github.com'
     - name: Install
-      run: npm install
+      # Skip post-install to avoid malicious scripts stealing PAT
+      run: npm install --ignore-script
       env:
         # GITHUB_TOKEN can't access packages hosted in private repos,
         # even within the same organisation
         NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Post-install
+      run: npm rebuild && npm run prepare --if-present
     - name: Publish
       run: npm publish
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,15 @@ jobs:
         node-version: '10.x'
         registry-url: 'https://npm.pkg.github.com'
     - name: Install
-      run: npm install
+      # Skip post-install to avoid malicious scripts stealing PAT
+      run: npm install --ignore-script
       env:
         # GITHUB_TOKEN can't access packages hosted in private repos,
         # even within the same organisation
         NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Post-install
+      run: npm rebuild && npm run prepare --if-present
+      env:
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     - name: Build
       run: npm run build


### PR DESCRIPTION
This change follows best practice for running `npm install` on Github
Actions, deferring running potentially malicious post-install scripts to
a scope that does not have access to reedsy-bot's Personal Access Token