### PR TITLE
Remove alias

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import {
   AttributorStore,
   BlockBlot,

--- a/core/editor.js
+++ b/core/editor.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import merge from 'lodash.merge';
-import Delta, { AttributeMap } from 'quill-delta';
+import Delta, { AttributeMap } from '@reedsy/quill-delta';
 import { LeafBlot } from 'parchment';
 import { Range } from './selection';
 import CursorBlot from '../blots/cursor';

--- a/core/quill.js
+++ b/core/quill.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import * as Parchment from 'parchment';

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import {
   Attributor,
   ClassAttributor,

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
-import Delta, { AttributeMap } from 'quill-delta';
+import Delta, { AttributeMap } from '@reedsy/quill-delta';
 import { EmbedBlot, Scope, TextBlot } from 'parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import { ClassAttributor, Scope } from 'parchment';
 import Inline from '../blots/inline';
 import Quill from '../core/quill';

--- a/modules/table.js
+++ b/modules/table.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Quill from '../core/quill';
 import Module from '../core/module';
 import {

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import { EmbedBlot, Scope } from 'parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';

--- a/modules/uploader.js
+++ b/modules/uploader.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Emitter from '../core/emitter';
 import Module from '../core/module';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.0.0",
+  "version": "2.0.0-reedsy-1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1136,6 +1136,16 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@reedsy/quill-delta": {
+      "version": "4.2.2-reedsy.1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@reedsy/quill-delta/4.2.2-reedsy.1.0.0/4e2d1b1bb6b29ad48d6504ac3f80dfb4bf5c515d605fca46efbb95675f88db88",
+      "integrity": "sha512-ykCfAoLCDqDcdWThEdTwwTV0rVRWaasUIyzLzbYxV+B+m6No8t+NgvJRchBVCTUMLujffIvB3Ir2yfz7ky/59g==",
+      "requires": {
+        "fast-diff": "1.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      }
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -9455,16 +9465,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
-    },
-    "quill-delta": {
-      "version": "npm:@reedsy/quill-delta@4.2.2-reedsy.1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@reedsy/quill-delta/4.2.2-reedsy.1.0.0/4e2d1b1bb6b29ad48d6504ac3f80dfb4bf5c515d605fca46efbb95675f88db88",
-      "integrity": "sha512-ykCfAoLCDqDcdWThEdTwwTV0rVRWaasUIyzLzbYxV+B+m6No8t+NgvJRchBVCTUMLujffIvB3Ir2yfz7ky/59g==",
-      "requires": {
-        "fast-diff": "1.2.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
-      }
     },
     "randombytes": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.0.0",
+  "version": "2.0.0-reedsy-1.0.1",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -32,12 +32,12 @@
     }
   },
   "dependencies": {
+    "@reedsy/quill-delta": "^4.2.2-reedsy.1.0.0",
     "eventemitter3": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.5.0",
-    "parchment": "2.0.0-dev.2",
-    "quill-delta": "npm:@reedsy/quill-delta@^4.2.2-reedsy.1.0.0"
+    "parchment": "2.0.0-dev.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 import Selection, { Range } from '../../../core/selection';
 

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Quill, { expandConfig, overload } from '../../../core/quill';
 import Theme from '../../../core/theme';
 import Emitter from '../../../core/emitter';

--- a/test/unit/formats/align.js
+++ b/test/unit/formats/align.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('Align', function() {

--- a/test/unit/formats/code.js
+++ b/test/unit/formats/code.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('Code', function() {

--- a/test/unit/formats/color.js
+++ b/test/unit/formats/color.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('Color', function() {

--- a/test/unit/formats/header.js
+++ b/test/unit/formats/header.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('Header', function() {

--- a/test/unit/formats/indent.js
+++ b/test/unit/formats/indent.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('Indent', function() {

--- a/test/unit/formats/link.js
+++ b/test/unit/formats/link.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 import Link from '../../../formats/link';
 

--- a/test/unit/formats/list.js
+++ b/test/unit/formats/list.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 describe('List', function() {

--- a/test/unit/formats/table.js
+++ b/test/unit/formats/table.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Editor from '../../../core/editor';
 
 const tableDelta = new Delta()

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import { Range } from '../../../core/selection';
 import Quill from '../../../core';
 

--- a/test/unit/modules/history.js
+++ b/test/unit/modules/history.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Quill from '../../../core';
 import { globalRegistry } from '../../../core/quill';
 import { getLastChangeIndex } from '../../../modules/history';

--- a/test/unit/modules/syntax.js
+++ b/test/unit/modules/syntax.js
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Quill from '../../../core/quill';
 import BoldBlot from '../../../formats/bold';
 import CodeBlock, { CodeBlockContainer } from '../../../formats/code';

--- a/test/unit/modules/table.js
+++ b/test/unit/modules/table.js
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@reedsy/quill-delta';
 import Quill from '../../../core/quill';
 
 describe('Table Module', function() {


### PR DESCRIPTION
`npm install` seems to fall over when nested dependencies have aliases,
so this change removes our use of an alias.