### PR TITLE
Change `Selection` into a module

### DIFF
--- a/core.js
+++ b/core.js
@@ -12,6 +12,7 @@ import TextBlot from './blots/text';
 import Clipboard from './modules/clipboard';
 import History from './modules/history';
 import Keyboard from './modules/keyboard';
+import Selection from './core/selection';
 import Uploader from './modules/uploader';
 
 Quill.register({
@@ -28,6 +29,7 @@ Quill.register({
   'modules/clipboard': Clipboard,
   'modules/history': History,
   'modules/keyboard': Keyboard,
+  'modules/selection': Selection,
   'modules/uploader': Uploader,
 });
 

--- a/core/quill.js
+++ b/core/quill.js
@@ -5,7 +5,7 @@ import * as Parchment from 'parchment';
 import Editor from './editor';
 import Emitter from './emitter';
 import Module from './module';
-import Selection, { Range } from './selection';
+import { Range } from './selection';
 import instances from './instances';
 import logger from './logger';
 import Theme from './theme';
@@ -86,8 +86,8 @@ class Quill {
       emitter: this.emitter,
     });
     this.editor = new Editor(this.scroll);
-    this.selection = new Selection(this.scroll, this.emitter);
     this.theme = new this.options.theme(this, this.options); // eslint-disable-line new-cap
+    this.selection = this.theme.addModule('selection');
     this.keyboard = this.theme.addModule('keyboard');
     this.clipboard = this.theme.addModule('clipboard');
     this.history = this.theme.addModule('history');
@@ -465,6 +465,7 @@ function expandConfig(container, userConfig) {
         clipboard: true,
         keyboard: true,
         history: true,
+        selection: true,
         uploader: true,
       },
     },

--- a/core/selection.js
+++ b/core/selection.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import Emitter from './emitter';
 import logger from './logger';
+import Module from './module';
 
 const debug = logger('quill:selection');
 
@@ -13,10 +14,11 @@ class Range {
   }
 }
 
-class Selection {
-  constructor(scroll, emitter) {
-    this.emitter = emitter;
-    this.scroll = scroll;
+class Selection extends Module {
+  constructor(quill, options) {
+    super(quill, options);
+    this.emitter = quill.emitter;
+    this.scroll = quill.scroll;
     this.composing = false;
     this.mouseDown = false;
     this.root = this.scroll.domNode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.0.2",
+  "version": "2.0.0-reedsy-1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.0.2",
+  "version": "2.0.0-reedsy-1.1.0",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",

--- a/test/helpers/unit.js
+++ b/test/helpers/unit.js
@@ -4,6 +4,11 @@ import Emitter from '../../core/emitter';
 import Selection from '../../core/selection';
 import Scroll from '../../blots/scroll';
 import Quill, { globalRegistry } from '../../core/quill';
+import CodeBlock, { CodeBlockContainer } from '../../formats/code';
+
+// Syntax version will otherwise be registered
+Quill.register(CodeBlockContainer, true);
+Quill.register(CodeBlock, true);
 
 const div = document.createElement('div');
 div.id = 'test-container';
@@ -127,9 +132,9 @@ function initialize(klass, html, container = this.container, options = {}) {
   const scroll = new Scroll(globalRegistry, container, { emitter });
   if (klass === Scroll) return scroll;
   if (klass === Editor) return new Editor(scroll);
-  if (klass === Selection) return new Selection(scroll, emitter);
+  if (klass === Selection) return new Selection({ scroll, emitter });
   if (klass[0] === Editor && klass[1] === Selection) {
-    return [new Editor(scroll), new Selection(scroll, emitter)];
+    return [new Editor(scroll), new Selection({ scroll, emitter })];
   }
   return null;
 }


### PR DESCRIPTION
This change turns `Selection` into a module. This allows deeper
customisation and proper method overriding, similar to `Keyboard`,
`Clipboard`, `Toolbar`, etc.