### PR TITLE
👷 Fix GitHub Actions build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,19 +11,12 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
         node-version: '10.x'
         registry-url: 'https://npm.pkg.github.com'
     - name: Install
-      # Skip post-install to avoid malicious scripts stealing PAT
-      run: npm install --ignore-script
-      env:
-        # GITHUB_TOKEN can't access packages hosted in private repos,
-        # even within the same organisation
-        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    - name: Post-install
-      run: npm rebuild && npm run prepare --if-present
+      run: npm install
     - name: Publish
       run: npm publish
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,23 +14,12 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-      with:
-        # Use PAT instead of default Github token, because the default
-        # token deliberately will not trigger another workflow run
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
         node-version: '10.x'
         registry-url: 'https://npm.pkg.github.com'
     - name: Install
-      # Skip post-install to avoid malicious scripts stealing PAT
-      run: npm install --ignore-script
-      env:
-        # GITHUB_TOKEN can't access packages hosted in private repos,
-        # even within the same organisation
-        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    - name: Post-install
-      run: npm rebuild && npm run prepare --if-present
+      run: npm install
       env:
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     - name: Build


### PR DESCRIPTION
This change moves us to use our org-wide PAT, as well as the
`setup-node` v2 action