### PR TITLE
➕ Move to `@reedsy/parchment` fork

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -5,7 +5,7 @@ import {
   EmbedBlot,
   LeafBlot,
   Scope,
-} from 'parchment';
+} from '@reedsy/parchment';
 import Break from './break';
 import Inline from './inline';
 import TextBlot from './text';

--- a/blots/break.js
+++ b/blots/break.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@reedsy/parchment';
 
 class Break extends EmbedBlot {
   static value() {

--- a/blots/container.js
+++ b/blots/container.js
@@ -1,4 +1,4 @@
-import { ContainerBlot } from 'parchment';
+import { ContainerBlot } from '@reedsy/parchment';
 
 class Container extends ContainerBlot {}
 

--- a/blots/cursor.js
+++ b/blots/cursor.js
@@ -1,4 +1,4 @@
-import { EmbedBlot, Scope } from 'parchment';
+import { EmbedBlot, Scope } from '@reedsy/parchment';
 import TextBlot from './text';
 
 class Cursor extends EmbedBlot {

--- a/blots/embed.js
+++ b/blots/embed.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@reedsy/parchment';
 import TextBlot from './text';
 
 const GUARD_TEXT = '\uFEFF';

--- a/blots/inline.js
+++ b/blots/inline.js
@@ -1,4 +1,4 @@
-import { EmbedBlot, InlineBlot, Scope } from 'parchment';
+import { EmbedBlot, InlineBlot, Scope } from '@reedsy/parchment';
 import Break from './break';
 import Text from './text';
 

--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -1,4 +1,4 @@
-import { Scope, ScrollBlot, ContainerBlot } from 'parchment';
+import { Scope, ScrollBlot, ContainerBlot } from '@reedsy/parchment';
 import Emitter from '../core/emitter';
 import Block, { BlockEmbed } from './block';
 import Break from './break';

--- a/blots/text.js
+++ b/blots/text.js
@@ -1,4 +1,4 @@
-import { TextBlot } from 'parchment';
+import { TextBlot } from '@reedsy/parchment';
 
 class Text extends TextBlot {}
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import merge from 'lodash.merge';
 import Delta, { AttributeMap } from '@reedsy/quill-delta';
-import { LeafBlot } from 'parchment';
+import { LeafBlot } from '@reedsy/parchment';
 import { Range } from './selection';
 import CursorBlot from '../blots/cursor';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block';

--- a/core/quill.js
+++ b/core/quill.js
@@ -1,7 +1,7 @@
 import Delta from '@reedsy/quill-delta';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
-import * as Parchment from 'parchment';
+import * as Parchment from '@reedsy/parchment';
 import Editor from './editor';
 import Emitter from './emitter';
 import Module from './module';

--- a/core/selection.js
+++ b/core/selection.js
@@ -1,4 +1,4 @@
-import { LeafBlot, Scope } from 'parchment';
+import { LeafBlot, Scope } from '@reedsy/parchment';
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import Emitter from './emitter';

--- a/formats/align.js
+++ b/formats/align.js
@@ -1,4 +1,9 @@
-import { Attributor, ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import {
+  Attributor,
+  ClassAttributor,
+  Scope,
+  StyleAttributor,
+} from '@reedsy/parchment';
 
 const config = {
   scope: Scope.BLOCK,

--- a/formats/background.js
+++ b/formats/background.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@reedsy/parchment';
 import { ColorAttributor } from './color';
 
 const BackgroundClass = new ClassAttributor('background', 'ql-bg', {

--- a/formats/color.js
+++ b/formats/color.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@reedsy/parchment';
 
 class ColorAttributor extends StyleAttributor {
   value(domNode) {

--- a/formats/direction.js
+++ b/formats/direction.js
@@ -1,4 +1,9 @@
-import { Attributor, ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import {
+  Attributor,
+  ClassAttributor,
+  Scope,
+  StyleAttributor,
+} from '@reedsy/parchment';
 
 const config = {
   scope: Scope.BLOCK,

--- a/formats/font.js
+++ b/formats/font.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@reedsy/parchment';
 
 const config = {
   scope: Scope.INLINE,

--- a/formats/image.js
+++ b/formats/image.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@reedsy/parchment';
 import { sanitize } from './link';
 
 const ATTRIBUTES = ['alt', 'height', 'width'];

--- a/formats/indent.js
+++ b/formats/indent.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@reedsy/parchment';
 
 class IndentAttributor extends ClassAttributor {
   add(node, value) {

--- a/formats/size.js
+++ b/formats/size.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@reedsy/parchment';
 
 const SizeClass = new ClassAttributor('size', 'ql-size', {
   scope: Scope.INLINE,

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -6,7 +6,7 @@ import {
   Scope,
   StyleAttributor,
   BlockBlot,
-} from 'parchment';
+} from '@reedsy/parchment';
 import { BlockEmbed } from '../blots/block';
 import Quill from '../core/quill';
 import logger from '../core/logger';

--- a/modules/history.js
+++ b/modules/history.js
@@ -1,4 +1,4 @@
-import { Scope } from 'parchment';
+import { Scope } from '@reedsy/parchment';
 import Quill from '../core/quill';
 import Module from '../core/module';
 

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import Delta, { AttributeMap } from '@reedsy/quill-delta';
-import { EmbedBlot, Scope, TextBlot } from 'parchment';
+import { EmbedBlot, Scope, TextBlot } from '@reedsy/parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -1,5 +1,5 @@
 import Delta from '@reedsy/quill-delta';
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@reedsy/parchment';
 import Inline from '../blots/inline';
 import Quill from '../core/quill';
 import Module from '../core/module';

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -1,5 +1,5 @@
 import Delta from '@reedsy/quill-delta';
-import { EmbedBlot, Scope } from 'parchment';
+import { EmbedBlot, Scope } from '@reedsy/parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.1.2",
+  "version": "2.0.0-reedsy-1.2.0",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -32,12 +32,12 @@
     }
   },
   "dependencies": {
+    "@reedsy/parchment": "^2.0.0-reedsy-1.0.0",
     "@reedsy/quill-delta": "^4.2.2-reedsy.1.0.1",
     "eventemitter3": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
-    "lodash.merge": "^4.5.0",
-    "parchment": "2.0.0-dev.2"
+    "lodash.merge": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
The `parchment` library hasn't had any commits since Dec 2019. This
change moves us onto a forked version, where we've emitted type
definitions.