### PR TITLE
Fix pasting HTML with newlines

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -291,6 +291,15 @@ function isLine(node) {
   ].includes(node.tagName.toLowerCase());
 }
 
+function isBetweenInlineElements(node) {
+  return (
+    node.previousSibling &&
+    node.nextSibling &&
+    !isLine(node.previousSibling) &&
+    !isLine(node.nextSibling)
+  );
+}
+
 const preNodes = new WeakMap();
 function isPre(node) {
   if (node == null) return false;
@@ -506,7 +515,11 @@ function matchText(node, delta) {
   if (node.parentNode.tagName === 'O:P') {
     return delta.insert(text.trim());
   }
-  if (text.trim().length === 0 && text.includes('\n')) {
+  if (
+    text.trim().length === 0 &&
+    text.includes('\n') &&
+    !isBetweenInlineElements(node)
+  ) {
     return delta;
   }
   if (!isPre(node)) {

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -171,6 +171,30 @@ describe('Clipboard', function() {
       );
     });
 
+    it('newlines between inline elements', function() {
+      const html = '<span>foo</span>\n<span>bar</span>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('foo bar'));
+    });
+
+    it('multiple newlines between inline elements', function() {
+      const html = '<span>foo</span>\n\n\n\n<span>bar</span>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('foo bar'));
+    });
+
+    it('newlines between block elements', function() {
+      const html = '<p>foo</p>\n<p>bar</p>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('foo\nbar'));
+    });
+
+    it('multiple newlines between block elements', function() {
+      const html = '<p>foo</p>\n\n\n\n<p>bar</p>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('foo\nbar'));
+    });
+
     it('break', function() {
       const html =
         '<div>0<br>1</div><div>2<br></div><div>3</div><div><br>4</div><div><br></div><div>5</div>';


### PR DESCRIPTION
At the moment, if you paste the following HTML, the newline between the
`<span>` elements is incorrectly discarded.

```html
<span>foo</span>
<span>bar</span>
```

This will currently insert `foobar` into Quill, when we'd expect
`foo bar`, since newlines should [treated as spaces][1] between inline
elements (such as `<span>`).

This change updates the `matchText()` clipboard matcher to check if the
text node is between inline elements or not before early-returning.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace