### PR TITLE
Ignore whitespace between pasted empty paragraphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.2.1",
+  "version": "2.0.0-reedsy-1.2.2",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -195,6 +195,18 @@ describe('Clipboard', function() {
       expect(delta).toEqual(new Delta().insert('foo\nbar'));
     });
 
+    it('space between empty paragraphs', function() {
+      const html = '<p></p> <p></p>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('\n'));
+    });
+
+    it('newline between empty paragraphs', function() {
+      const html = '<p></p>\n<p></p>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(new Delta().insert('\n'));
+    });
+
     it('break', function() {
       const html =
         '<div>0<br>1</div><div>2<br></div><div>3</div><div><br>4</div><div><br></div><div>5</div>';


### PR DESCRIPTION
At the moment, when pasting HTML containing empty paragraphs with
whitespace between them, the whitespace is incorrectly rendered.

For example:

```html
<p></p> <p></p>
```

will result in a Delta containing `' \n'`

This happens because the clipboard's `isLine()` function assumes that
any element without children is an embed (which isn't true for things
like empty paragraphs).

This change updates the `isLine()` check to check the node against the
registry, and see if we have a matching `EmbedBlot` there.