### PR TITLE
Run clipboard matchers against plain text pastes

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -86,7 +86,10 @@ class Clipboard extends Module {
       });
     }
     if (!html) {
-      return new Delta().insert(text || '');
+      html = (text || '')
+        .split('\n')
+        .map(line => `<p>${line}</p>`)
+        .join('');
     }
     const delta = this.convertHTML(html);
     // Remove trailing newline

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -438,6 +438,30 @@ describe('Clipboard', function() {
       expect(delta).toEqual(expected);
     });
 
+    it('runs a text node matcher on a plain text paste', function() {
+      this.clipboard.addMatcher(Node.TEXT_NODE, function(node, delta) {
+        let index = 0;
+        const regex = /https?:\/\/[^\s]+/g;
+        let match = null;
+        const composer = new Delta();
+        // eslint-disable-next-line no-cond-assign
+        while ((match = regex.exec(node.data))) {
+          composer.retain(match.index - index);
+          index = regex.lastIndex;
+          composer.retain(match[0].length, { link: match[0] });
+        }
+        return delta.compose(composer);
+      });
+      const delta = this.clipboard.convert({
+        text: 'http://github.com https://quilljs.com',
+      });
+      const expected = new Delta()
+        .insert('http://github.com', { link: 'http://github.com' })
+        .insert(' ')
+        .insert('https://quilljs.com', { link: 'https://quilljs.com' });
+      expect(delta).toEqual(expected);
+    });
+
     it('does not execute javascript', function() {
       window.unsafeFunction = jasmine.createSpy('unsafeFunction');
       const html =


### PR DESCRIPTION
At the moment, if the clipboard pastes `text/plain` content and no
`text/html` content, the `Clipboard.convert()` function will completely
skip the matching logic.

This is surprising when registering text node clipboard matchers.

This change updates the `convert()` function to change the plain text
into basic HTML, which is passed through the matchers.

The conversion interprets newlines as paragraph `<p>` elements,
consistent with Quill's existing behaviour.