### PR TITLE
⚡️ Replace `lodash` with faster tools

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -1,5 +1,5 @@
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import rfdc from 'rfdc';
+import isEqual from 'fast-deep-equal';
 import merge from 'lodash.merge';
 import Delta, { AttributeMap, Op } from '@reedsy/quill-delta';
 import { LeafBlot, Scope } from '@reedsy/parchment';
@@ -9,6 +9,7 @@ import Block, { BlockEmbed, bubbleFormats } from '../blots/block';
 import Break from '../blots/break';
 import TextBlot, { escapeText } from '../blots/text';
 
+const cloneDeep = rfdc();
 const ASCII = /^[ -~]*$/;
 
 class Editor {

--- a/core/quill.js
+++ b/core/quill.js
@@ -1,5 +1,5 @@
 import Delta from '@reedsy/quill-delta';
-import cloneDeep from 'lodash.clonedeep';
+import rfdc from 'rfdc';
 import merge from 'lodash.merge';
 import * as Parchment from '@reedsy/parchment';
 import Editor from './editor';
@@ -10,6 +10,7 @@ import instances from './instances';
 import logger from './logger';
 import Theme from './theme';
 
+const cloneDeep = rfdc();
 const debug = logger('quill');
 
 const globalRegistry = new Parchment.Registry();

--- a/core/selection.js
+++ b/core/selection.js
@@ -1,10 +1,11 @@
 import { LeafBlot, Scope } from '@reedsy/parchment';
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import rfdc from 'rfdc';
+import isEqual from 'fast-deep-equal';
 import Emitter from './emitter';
 import logger from './logger';
 import Module from './module';
 
+const cloneDeep = rfdc();
 const debug = logger('quill:selection');
 
 class Range {

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -1,11 +1,12 @@
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import rfdc from 'rfdc';
+import isEqual from 'fast-deep-equal';
 import Delta, { AttributeMap } from '@reedsy/quill-delta';
 import { EmbedBlot, Scope, TextBlot } from '@reedsy/parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';
 
+const cloneDeep = rfdc();
 const debug = logger('quill:keyboard');
 
 const SHORTKEY = /Mac/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.2.3",
+  "version": "2.0.0-reedsy-1.2.4",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -38,9 +38,9 @@
     "@reedsy/parchment": "^2.0.0-reedsy-1.0.0",
     "@reedsy/quill-delta": "^4.2.2-reedsy.1.0.1",
     "eventemitter3": "^4.0.0",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
-    "lodash.merge": "^4.5.0"
+    "fast-deep-equal": "^3.1.3",
+    "lodash.merge": "^4.5.0",
+    "rfdc": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/test/helpers/unit.js
+++ b/test/helpers/unit.js
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import isEqual from 'fast-deep-equal';
 import Editor from '../../core/editor';
 import Emitter from '../../core/emitter';
 import Selection from '../../core/selection';


### PR DESCRIPTION
This change replaces `lodash.clonedeep` with [`rfdc`][1], which claims
to be ~4x faster and `lodash.isequal` with [`fast-deep-equal`][2], which
claims to be ~7x faster.

[1]: https://github.com/davidmarkclements/rfdc#readme
[2]: https://github.com/epoberezkin/fast-deep-equal