### PR TITLE
🐛 Fix keyboard bindings

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -1,4 +1,4 @@
-import rfdc from 'rfdc';
+import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'fast-deep-equal';
 import Delta, { AttributeMap } from '@reedsy/quill-delta';
 import { EmbedBlot, Scope, TextBlot } from '@reedsy/parchment';
@@ -6,7 +6,6 @@ import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';
 
-const cloneDeep = rfdc();
 const debug = logger('quill:keyboard');
 
 const SHORTKEY = /Mac/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-1.2.4",
+  "version": "2.0.0-reedsy-1.2.5",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -39,6 +39,7 @@
     "@reedsy/quill-delta": "^4.2.2-reedsy.1.0.1",
     "eventemitter3": "^4.0.0",
     "fast-deep-equal": "^3.1.3",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.5.0",
     "rfdc": "^1.3.0"
   },


### PR DESCRIPTION
We just [swapped][1] `lodash.clonedeep` for the more performance `rfdc`.
However, the Keyboard module tries to deep clone objects containing
`RegExp` objects, which `lodash.clonedeep` handles fine, but `rfdc`
strips.

This change puts back `lodash.clonedeep` just in the Keyboard module to
handle this case, keeping `rfdc` everywhere else.

[1]: https://github.com/reedsy/quill/pull/30