### PR TITLE
🐛 Fix `context.range` updates

### DIFF
--- a/core/selection.ts
+++ b/core/selection.ts
@@ -88,11 +88,16 @@ class Selection extends Module {
       });
     });
     this.emitter.on(Emitter.events.SCROLL_OPTIMIZE, (mutations, context) => {
-      if (context.range) {
+      if (!context.range) return;
+      // Perform this in a setTimeout() to let the browser finish reacting to
+      // user input before attempting to set the selection. This also has the
+      // side-effect of waiting until after the SCROLL_UPDATE listener above,
+      // which tries to reset the user selection to what it was before the update.
+      setTimeout(() => {
         const { startNode, startOffset, endNode, endOffset } = context.range;
         this.setNativeRange(startNode, startOffset, endNode, endOffset);
         this.update(Emitter.sources.SILENT);
-      }
+      });
     });
     this.update(Emitter.sources.SILENT);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.0.3",
+  "version": "2.0.0-reedsy-2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/quill",
-      "version": "2.0.0-reedsy-2.0.3",
+      "version": "2.0.0-reedsy-2.0.4",
       "license": "BSD-3-Clause",
       "workspaces": [
         "website"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.0.3",
+  "version": "2.0.0-reedsy-2.0.4",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",

--- a/test/unit/core/selection.js
+++ b/test/unit/core/selection.js
@@ -1,6 +1,8 @@
 import Selection, { Range } from '../../../core/selection';
 import Cursor from '../../../blots/cursor';
 import Emitter from '../../../core/emitter';
+import Quill from '../../../core/quill';
+import Inline from '../../../blots/inline';
 
 describe('Selection', function() {
   beforeEach(function() {
@@ -655,6 +657,44 @@ describe('Selection', function() {
       expect(() => {
         this.bounds = selection.getBounds(0, 10);
       }).not.toThrow();
+    });
+  });
+
+  describe('context.range update', function() {
+    it('updates the selection from the optimize context', function(done) {
+      class TestSelectorOffset1 extends Inline {
+        static tagName = 'SPAN';
+        static blotName = 'test-selector-offset-1';
+        static className = 'ql-test-selector-offset-1';
+
+        static formats() {
+          return true;
+        }
+
+        optimize(context) {
+          context.range = {
+            startNode: this.domNode.childNodes[0],
+            startOffset: 1,
+          };
+        }
+      }
+
+      Quill.register(TestSelectorOffset1);
+
+      const quill = this.initialize(
+        Quill,
+        '<p><span class="ql-test-selector-offset-1">abce</span></p>',
+      );
+
+      quill.setSelection(3);
+      document.execCommand('insertText', false, 'd');
+
+      setTimeout(() => {
+        const range = quill.getSelection();
+        expect(range.index).toBe(1);
+        expect(range.length).toBe(0);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
The `Selection` class has a (hidden) feature that allows blots to update the selection from their `optimize()` hooks by setting [`context.range`][1].

This is currently used by [`Embed`s][2] for example, to correct the selection if their guards are edited.

The current implementation has a couple of bugs, though.

The first bug is that the selection is currently during the `SCROLL_OPTIMIZE` event. However, since this is called *before* the `SCROLL_UPDATE` event, the `Selection` then clobbers any changes made by trying to [put back the previous selection][3].

The second bug is more subtle, and I sadly couldn't write a failing test case for it, since it seems Android-specific: if a blot removes itself in response to user input, *and* also updates `context.range`, then the browser will attempt to update the selection in response to the user input, which happens after the Quill events are done processing.

In order to update the selection after this, we move the `context.range` update into a `setTimeout()` call, which should let the browser finish processing the current user input before we try to update the selection.

Using a `setTimeout()` isn't ideal, since it introduces some non-deterministic behaviour, but it looks like this workaround was also added to deal with [`compositionend`][4].

[1]: https://github.com/reedsy/quill/blob/d2ea83a81fa6104bbf9be4349a73a74b97f33c26/core/selection.ts#L91
[2]: https://github.com/reedsy/quill/blob/d2ea83a81fa6104bbf9be4349a73a74b97f33c26/blots/embed.ts#L79
[3]: https://github.com/reedsy/quill/blob/d2ea83a81fa6104bbf9be4349a73a74b97f33c26/core/selection.ts#L60-L89
[4]: https://github.com/quilljs/quill/commit/e7809196f851794a53f12033cedf73054b02e8d8