### PR TITLE
🏷️ Declare type definition file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.0.4",
+  "version": "2.0.0-reedsy-2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/quill",
-      "version": "2.0.0-reedsy-2.0.4",
+      "version": "2.0.0-reedsy-2.0.5",
       "license": "BSD-3-Clause",
       "workspaces": [
         "website"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.0.4",
+  "version": "2.0.0-reedsy-2.0.5",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
   "main": "dist/quill.js",
+  "types": "quill.d.ts",
   "config": {
     "ports": {
       "proxy": "9000",


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill/issues/35

At the moment, importing the default import from `@reedsy/quill` does not have any type definitions, and will result in a compiler error.

This change fixes this by pointing the `package.json` [`types` ][1] fields to the already-generated `quill.d.ts` file.

[1]: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package