### PR TITLE
♻️ Add `Keyboard.shouldHandleKeydown()` method

### DIFF
--- a/modules/keyboard.ts
+++ b/modules/keyboard.ts
@@ -167,7 +167,7 @@ class Keyboard extends Module<KeyboardOptions> {
 
   listen() {
     this.quill.root.addEventListener('keydown', evt => {
-      if (evt.defaultPrevented || evt.isComposing) return;
+      if (!this.shouldHandleKeydown(evt)) return;
       const bindings = (this.bindings[evt.key] || []).concat(
         this.bindings[evt.which] || [],
       );
@@ -328,6 +328,10 @@ class Keyboard extends Module<KeyboardOptions> {
     this.quill.updateContents(delta, Quill.sources.USER);
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
     this.quill.focus();
+  }
+
+  protected shouldHandleKeydown(event: KeyboardEvent): boolean {
+    return !event.defaultPrevented && !event.isComposing;
   }
 }
 


### PR DESCRIPTION
The `Keyboard` module's `keydown` listener doesn't handle events if the IME is composing.

This behaviour was was added in https://github.com/quilljs/quill/commit/2f608ab4c15bbda6ee4d32354fa2d2b259507055

I'm not sure what problem it was trying to solve, but it adds a new problem: since Android's GBoard is basically always in composing mode, you can't backspace bullet points, because the handler ignores the event.

This change keeps the existing upstream behaviour, but moves it into a `shouldHandleKeydown` method, which our subclass can override.