### PR TITLE
👷‍♀️ Increase e2e retries on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
-        "@playwright/test": "^1.27.1",
+        "@playwright/test": "^1.32.3",
         "@types/jasmine": "^4.3.0",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -3574,19 +3574,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
-      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "playwright-core": "1.32.3"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -18473,9 +18476,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -27048,13 +27051,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
-      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.3"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -38142,9 +38146,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.4",
-    "@playwright/test": "^1.27.1",
+    "@playwright/test": "^1.32.3",
     "@types/jasmine": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,7 @@ const config = {
     },
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
-    retries: process.env.CI ? 2 : 0,
+    retries: process.env.CI ? 10 : 0,
     workers: process.env.CI ? 1 : undefined,
     reporter: 'list',
     use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ const config: PlaywrightTestConfig = {
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 10 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
   use: {


### PR DESCRIPTION
The e2e tests on GH Actions are currently super flaky. Since we have to wait 2 minutes before even running the tests, this change bumps the number of retries to 10 to see if they can pass without having to retry the whole action.