### PR TITLE
✅ Improve e2e flakiness

### DIFF
--- a/e2e/full.spec.js
+++ b/e2e/full.spec.js
@@ -17,6 +17,11 @@ const utils_1 = require("./utils");
 const fixtures_1 = require("./utils/fixtures");
 const QuillPage_1 = __importDefault(require("./utils/QuillPage"));
 (0, test_1.test)('compose an epic', ({ page }) => __awaiter(void 0, void 0, void 0, function* () {
+    const type = page.type.bind(page);
+    page.type = (selector, text, options) => __awaiter(void 0, void 0, void 0, function* () {
+        options = Object.assign({ delay: 1 }, options);
+        return type(selector, text, options);
+    });
     yield page.goto('http://localhost:9000/standalone/full');
     const quillPage = new QuillPage_1.default(page);
     yield page.waitForSelector('.ql-editor', { timeout: 10000 });

--- a/e2e/full.spec.ts
+++ b/e2e/full.spec.ts
@@ -4,6 +4,15 @@ import { CHAPTER, P1, P2 } from './utils/fixtures';
 import QuillPage from './utils/QuillPage';
 
 test('compose an epic', async ({ page }) => {
+  const type = page.type.bind(page);
+  page.type = async (selector, text, options) => {
+    options = {
+      delay: 1,
+      ...options,
+    };
+    return type(selector, text, options);
+  };
+
   await page.goto('http://localhost:9000/standalone/full');
   const quillPage = new QuillPage(page);
   await page.waitForSelector('.ql-editor', { timeout: 10000 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
-        "@playwright/test": "^1.27.1",
+        "@playwright/test": "^1.32.3",
         "@types/jasmine": "^4.3.0",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -3574,19 +3574,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
-      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "playwright-core": "1.32.3"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -18473,9 +18476,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -27048,13 +27051,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
-      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.3"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -38142,9 +38146,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.4",
-    "@playwright/test": "^1.27.1",
+    "@playwright/test": "^1.32.3",
     "@types/jasmine": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",


### PR DESCRIPTION
At the moment our e2e tests are extremely flaky. In particular, they seem to struggle with the `Cursor` blot:

```
      127 |
      128 |   await page.type('.ql-editor', 'Moby Dick');
    > 129 |   expect(await quillPage.editorHTML()).toEqual(
          |                                        ^
      130 |     [
      131 |       '<p><strong><em>Moby Dick</em></strong></p>',
      132 |       `<p>${CHAPTER}</p>`,

        at /home/runner/work/quill/quill/e2e/full.spec.ts:129:40
```

We get "Moby Dick" out of order:

```
    Received: "<p><strong><em>Mby Dicko</em></strong></p>
```

This change attempts to give the `Cursor` blot time to update by setting a default `page.type()` [delay][1].

[1]: https://playwright.dev/docs/api/class-keyboard#keyboard-type