### PR TITLE
🏷️ Fix `addModule()` types

### DIFF
--- a/themes/base.ts
+++ b/themes/base.ts
@@ -7,6 +7,11 @@ import IconPicker from '../ui/icon-picker';
 import Picker from '../ui/picker';
 import Tooltip from '../ui/tooltip';
 import { Range } from '../core/selection';
+import Clipboard from '../modules/clipboard';
+import History from '../modules/history';
+import Keyboard from '../modules/keyboard';
+import Uploader from '../modules/uploader';
+import Selection from '../core/selection';
 
 const ALIGNS = [false, 'center', 'right', 'justify'];
 
@@ -87,7 +92,12 @@ class BaseTheme extends Theme {
     quill.emitter.listenDOM('click', document.body, listener);
   }
 
-  // @ts-expect-error
+  addModule(name: 'clipboard'): Clipboard;
+  addModule(name: 'keyboard'): Keyboard;
+  addModule(name: 'uploader'): Uploader;
+  addModule(name: 'history'): History;
+  addModule(name: 'selection'): Selection;
+  addModule(name: string): unknown;
   addModule(name: string) {
     const module = super.addModule(name);
     if (name === 'toolbar') {


### PR DESCRIPTION
At the moment, since `@ts-expect-error` [doesn't apply][1] to type definitions, we get a downstream compilation error:

```
TS2416: Property 'addModule' in type 'BaseTheme' is not assignable to the same property in base type 'Theme'.
  Type '(name: string) => unknown' is not assignable to type '{ (name: "clipboard"): Clipboard; (name: "keyboard"): Keyboard; (name: "uploader"): Uploader; (name: "history"): History; (name: "selection"): Selection; (name: string): unknown; }'.
    Type '{}' is missing the following properties from type 'Clipboard': matchers, addMatcher, convert, convertHTML, and 8 more.

10     addModule(name: string): unknown;
```

This change updates the `Base` class to have the same signature as for `addModule()` as its parent class.

[1]: https://github.com/microsoft/TypeScript/issues/38628