### PR TITLE
💥 Remove `Emitter.listeners` type clash

### DIFF
--- a/core/emitter.ts
+++ b/core/emitter.ts
@@ -35,12 +35,13 @@ class Emitter extends EventEmitter<string> {
     USER: 'user',
   } as const;
 
-  // @ts-expect-error listeners is declared in EventEmitter as a function
-  listeners: Record<string, { node: Node; handler: Function }[]>;
+  private readonly DOMListeners: Record<
+    string,
+    { node: Node; handler: Function }[]
+  > = {};
 
   constructor() {
     super();
-    this.listeners = {};
     this.on('error', debug.error);
   }
 
@@ -51,7 +52,7 @@ class Emitter extends EventEmitter<string> {
   }
 
   handleDOM(event, ...args: unknown[]) {
-    (this.listeners[event.type] || []).forEach(({ node, handler }) => {
+    (this.DOMListeners[event.type] || []).forEach(({ node, handler }) => {
       if (event.target === node || node.contains(event.target)) {
         handler(event, ...args);
       }
@@ -59,10 +60,10 @@ class Emitter extends EventEmitter<string> {
   }
 
   listenDOM(eventName: string, node, handler) {
-    if (!this.listeners[eventName]) {
-      this.listeners[eventName] = [];
+    if (!this.DOMListeners[eventName]) {
+      this.DOMListeners[eventName] = [];
     }
-    this.listeners[eventName].push({ node, handler });
+    this.DOMListeners[eventName].push({ node, handler });
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.1.1",
+  "version": "2.0.0-reedsy-3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/quill",
-      "version": "2.0.0-reedsy-2.1.1",
+      "version": "2.0.0-reedsy-3.0.0",
       "license": "BSD-3-Clause",
       "workspaces": [
         "website"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-2.1.1",
+  "version": "2.0.0-reedsy-3.0.0",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",


### PR DESCRIPTION
At the moment, since `@ts-expect-error` [doesn't apply][1] to type definitions, we get a downstream compilation error:

```
TS2416: Property 'listeners' in type 'Emitter' is not assignable to the same property in base type 'EventEmitter<string, any>'.
  Type 'Record<string, { node: Node; handler: Function; }[]>' is not assignable to type '<T extends string>(event: T) => ((...args: any[]) => void)[]'.
    Type 'Record<string, { node: Node; handler: Function; }[]>' provides no match for the signature '<T extends string>(event: T): ((...args: any[]) => void)[]'.

19     listeners: Record<string, {
```

This change removes the clash by renaming the internal variable. Note that, since `listeners` is `public`, this is technically breaking.

[1]: https://github.com/microsoft/TypeScript/issues/38628