### PR TITLE
🏷️ Fix `BaseTooltip.edit()` signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-3.0.1",
+  "version": "2.0.0-reedsy-3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/quill",
-      "version": "2.0.0-reedsy-3.0.1",
+      "version": "2.0.0-reedsy-3.0.2",
       "license": "BSD-3-Clause",
       "workspaces": [
         "website"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-3.0.1",
+  "version": "2.0.0-reedsy-3.0.2",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",

--- a/themes/base.ts
+++ b/themes/base.ts
@@ -237,7 +237,7 @@ class BaseTooltip extends Tooltip {
     this.hide();
   }
 
-  edit(mode = 'link', preview = null) {
+  edit(mode = 'link', preview: string | null = null) {
     this.root.classList.remove('ql-hidden');
     this.root.classList.add('ql-editing');
     if (preview != null) {


### PR DESCRIPTION
At the moment, the `BaseTooltip.edit()` signature has type:

```ts
declare class BaseTooltip extends Tooltip {
  edit(mode?: string, preview?: null): void;
}
```

This change tweaks the signature to be more accurate:

```ts
declare class BaseTooltip extends Tooltip {
  edit(mode?: string, preview?: string | null): void;
}
```