### PR TITLE
📌 Pin `parchment@3.0.0-alpha.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-4.0.0",
+  "version": "2.0.0-reedsy-4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/quill",
-      "version": "2.0.0-reedsy-4.0.0",
+      "version": "2.0.0-reedsy-4.0.1",
       "license": "BSD-3-Clause",
       "workspaces": [
         "website"
@@ -17,7 +17,7 @@
         "fast-deep-equal": "^3.1.3",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.5.0",
-        "parchment": "^3.0.0-alpha.1",
+        "parchment": "3.0.0-alpha.1",
         "rfdc": "^1.3.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-4.0.0",
+  "version": "2.0.0-reedsy-4.0.1",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -23,7 +23,7 @@
     "fast-deep-equal": "^3.1.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.5.0",
-    "parchment": "^3.0.0-alpha.1",
+    "parchment": "3.0.0-alpha.1",
     "rfdc": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`parchment@3.0.0-alpha.2` makes some breaking changes that we need to adapt to when we eventually catch up to upstream `quill`.

For now, let's pin our version of `parchment` to avoid breaking downstream builds that try to bump `parchment`.