### PR TITLE
Revert "Preserve es modules in babel config (#4013)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Fix toolbar button state not updated in some cases
 - Narrower `BubbleTheme.tooltip` type
 - Fix `Selection.getBounds()` when starting range at end of text node
-- Improve compatibility with esbuild
 
 # 2.0.0-rc.1
 

--- a/packages/quill/babel.config.js
+++ b/packages/quill/babel.config.js
@@ -1,10 +1,7 @@
 const pkg = require('./package.json');
 
 module.exports = {
-  presets: [
-    ['@babel/preset-env', { modules: false }],
-    '@babel/preset-typescript'
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: [
     ['transform-define', { QUILL_VERSION: pkg.version }],
     './scripts/babel-svg-inline-import',

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.0-reedsy-5.0.1",
+  "version": "2.0.0-reedsy-5.0.2",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",


### PR DESCRIPTION
This reverts commit 5fa786c5ff1d8a01fb17fd5cde7e83c5e6c8815f.

Upstream merged a change that ships ESM directly, with no transformation through babel, and without marking the library as `"type": "module"`

This breaks some of our Node.js tests, which (correctly) complain that Quill shouldn't be using `import` statements without declaring itself as an ESM library with `"type": "module"`.

This change just reverts the break.