### PR TITLE
⬆️ Bump `@reedsy/quill-delta`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,16 @@
       "workspaces": [
         "packages/*"
       ],
-      "optionalDependencies": {
-        "@esbuild/linux-x64": "0.25.8",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1"
-      },
       "devDependencies": {
         "execa": "^9.0.2",
         "npm-run-all": "^4.1.5"
       },
       "engines": {
         "npm": ">=8.2.3"
+      },
+      "optionalDependencies": {
+        "@esbuild/linux-x64": "0.25.8",
+        "@rollup/rollup-linux-x64-gnu": "4.45.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2060,6 +2060,8 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
       "cpu": [
         "x64"
       ],
@@ -4744,7 +4746,9 @@
       "link": true
     },
     "node_modules/@reedsy/quill-delta": {
-      "version": "5.1.0-reedsy.3.0.0",
+      "version": "5.1.0-reedsy.4.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@reedsy/quill-delta/5.1.0-reedsy.4.0.0/000d026fa1956a3f31edc47964750e92b97ef627",
+      "integrity": "sha512-0qubX6x5E4NYSpdasaE1oVU0BWe4DwFMSTj6YNdBDXszN5lsfqWbLZBwLmUJAqdA4dj6DsP6UdyMejMW24ddPg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4769,8 +4773,13 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -9217,8 +9226,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -17206,10 +17213,10 @@
     },
     "packages/quill": {
       "name": "@reedsy/quill",
-      "version": "2.0.3-reedsy-5.0.9",
+      "version": "2.0.3-reedsy-5.0.10",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@reedsy/quill-delta": "=5.1.0-reedsy.3.0.0",
+        "@reedsy/quill-delta": "^5.1.0-reedsy.4.0.0",
         "eventemitter3": "^5.0.1",
         "fast-deep-equal": "^3.1.3",
         "lodash-es": "^4.17.21",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.3-reedsy-5.0.9",
+  "version": "2.0.3-reedsy-5.0.10",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",
   "main": "quill.js",
   "type": "module",
   "dependencies": {
-    "@reedsy/quill-delta": "=5.1.0-reedsy.3.0.0",
+    "@reedsy/quill-delta": "^5.1.0-reedsy.4.0.0",
     "eventemitter3": "^5.0.1",
     "fast-deep-equal": "^3.1.3",
     "lodash-es": "^4.17.21",

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -6,7 +6,7 @@ import {
   Scope,
 } from 'parchment';
 import type { Blot, Parent } from 'parchment';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Break from './break.js';
 import Inline from './inline.js';
 import TextBlot from './text.js';

--- a/packages/quill/src/blots/scroll.ts
+++ b/packages/quill/src/blots/scroll.ts
@@ -1,6 +1,6 @@
 import { ContainerBlot, LeafBlot, Scope, ScrollBlot } from 'parchment';
 import type { Blot, Parent, EmbedBlot, ParentBlot, Registry } from 'parchment';
-import Delta, { AttributeMap, Op } from '@reedsy/quill-delta';
+import { Delta, AttributeMap, Op } from '@reedsy/quill-delta';
 import Emitter from '../core/emitter.js';
 import type { EmitterSource } from '../core/emitter.js';
 import Block, { BlockEmbed, bubbleFormats } from './block.js';

--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -20,7 +20,7 @@ import Clipboard from './modules/clipboard.js';
 import History from './modules/history.js';
 import Keyboard from './modules/keyboard.js';
 import Uploader from './modules/uploader.js';
-import Delta, { Op, OpIterator, AttributeMap } from '@reedsy/quill-delta';
+import { Delta, Op, OpIterator, AttributeMap } from '@reedsy/quill-delta';
 import Input from './modules/input.js';
 import Composition from './core/composition.js';
 import Selection from './core/selection.js';

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -3,7 +3,7 @@ import isEqual from 'fast-deep-equal';
 import { merge } from 'lodash-es';
 import { LeafBlot, EmbedBlot, Scope, ParentBlot } from 'parchment';
 import type { Blot } from 'parchment';
-import Delta, { AttributeMap, Op } from '@reedsy/quill-delta';
+import { Delta, AttributeMap, Op } from '@reedsy/quill-delta';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block.js';
 import Break from '../blots/break.js';
 import CursorBlot from '../blots/cursor.js';

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash-es';
 import * as Parchment from 'parchment';
 import type { Op } from '@reedsy/quill-delta';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import type { BlockEmbed } from '../blots/block.js';
 import type Block from '../blots/block.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -7,7 +7,7 @@ import {
   Scope,
   StyleAttributor,
 } from 'parchment';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { BlockEmbed } from '../blots/block.js';
 import type { EmitterSource } from '../core/emitter.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/history.ts
+++ b/packages/quill/src/modules/history.ts
@@ -1,5 +1,5 @@
 import { Scope } from 'parchment';
-import type Delta from '@reedsy/quill-delta';
+import type { Delta } from '@reedsy/quill-delta';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/input.ts
+++ b/packages/quill/src/modules/input.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type { Range } from '../core/selection.js';

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash-es';
 import isEqual from 'fast-deep-equal';
-import Delta, { AttributeMap } from '@reedsy/quill-delta';
+import { Delta, AttributeMap } from '@reedsy/quill-delta';
 import { EmbedBlot, Scope, TextBlot } from 'parchment';
 import type { Blot, BlockBlot } from 'parchment';
 import Quill from '../core/quill.js';

--- a/packages/quill/src/modules/syntax.ts
+++ b/packages/quill/src/modules/syntax.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { ClassAttributor, Scope } from 'parchment';
 import type { Blot, ScrollBlot } from 'parchment';
 import Inline from '../blots/inline.js';

--- a/packages/quill/src/modules/table.ts
+++ b/packages/quill/src/modules/table.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Quill from '../core/quill.js';
 import Module from '../core/module.js';
 import {

--- a/packages/quill/src/modules/tableEmbed.ts
+++ b/packages/quill/src/modules/tableEmbed.ts
@@ -1,5 +1,5 @@
-import Delta, { OpIterator } from '@reedsy/quill-delta';
-import type { Op, AttributeMap } from '@reedsy/quill-delta';
+import { Delta, AttributeMap, OpIterator } from '@reedsy/quill-delta';
+import type { Op } from '@reedsy/quill-delta';
 import Module from '../core/module.js';
 
 export type CellData = {
@@ -136,7 +136,7 @@ export const tableHandler = {
         new Delta(bCell.content || []),
       );
 
-      const attributes = Delta.AttributeMap.compose(
+      const attributes = AttributeMap.compose(
         aCell.attributes,
         bCell.attributes,
         keepNull,
@@ -190,7 +190,7 @@ export const tableHandler = {
             priority,
           );
 
-          const attributes = Delta.AttributeMap.transform(
+          const attributes = AttributeMap.transform(
             aCell.attributes,
             bCell.attributes,
             priority,
@@ -225,7 +225,7 @@ export const tableHandler = {
       const content = new Delta(changeCell.content || []).invert(
         new Delta(baseCell.content || []),
       );
-      const attributes = Delta.AttributeMap.invert(
+      const attributes = AttributeMap.invert(
         changeCell.attributes,
         baseCell.attributes,
       );

--- a/packages/quill/src/modules/toolbar.ts
+++ b/packages/quill/src/modules/toolbar.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { EmbedBlot, Scope } from 'parchment';
 import Quill from '../core/quill.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/uploader.ts
+++ b/packages/quill/src/modules/uploader.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Module from '../core/module.js';

--- a/packages/quill/test/fuzz/editor.spec.ts
+++ b/packages/quill/test/fuzz/editor.spec.ts
@@ -1,5 +1,5 @@
 import type { Op } from '@reedsy/quill-delta';
-import Delta, { AttributeMap } from '@reedsy/quill-delta';
+import { Delta, AttributeMap } from '@reedsy/quill-delta';
 import { choose, randomInt, runFuzz } from './__helpers__/utils.js';
 import { AlignClass } from '../../src/formats/align.js';
 import { FontClass } from '../../src/formats/font.js';

--- a/packages/quill/test/fuzz/tableEmbed.spec.ts
+++ b/packages/quill/test/fuzz/tableEmbed.spec.ts
@@ -1,5 +1,5 @@
 import type { AttributeMap } from '@reedsy/quill-delta';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import TableEmbed from '../../src/modules/tableEmbed.js';
 import type {
   CellData,

--- a/packages/quill/test/unit/blots/scroll.spec.ts
+++ b/packages/quill/test/unit/blots/scroll.spec.ts
@@ -3,7 +3,7 @@ import Emitter from '../../../src/core/emitter.js';
 import Selection, { Range } from '../../../src/core/selection.js';
 import Cursor from '../../../src/blots/cursor.js';
 import Scroll from '../../../src/blots/scroll.js';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { createRegistry } from '../__helpers__/factory.js';
 import { normalizeHTML, sleep } from '../__helpers__/utils.js';
 import Underline from '../../../src/formats/underline.js';

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Editor from '../../../src/core/editor.js';
 import Block from '../../../src/blots/block.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -1,5 +1,5 @@
 import '../../../src/quill.js';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { LeafBlot, Registry } from 'parchment';
 import {
   afterEach,

--- a/packages/quill/test/unit/formats/align.spec.ts
+++ b/packages/quill/test/unit/formats/align.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Editor from '../../../src/core/editor.js';
 import { describe, test, expect } from 'vitest';
 import {

--- a/packages/quill/test/unit/formats/code.spec.ts
+++ b/packages/quill/test/unit/formats/code.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/color.spec.ts
+++ b/packages/quill/test/unit/formats/color.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/header.spec.ts
+++ b/packages/quill/test/unit/formats/header.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/indent.spec.ts
+++ b/packages/quill/test/unit/formats/indent.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/link.spec.ts
+++ b/packages/quill/test/unit/formats/link.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/list.spec.ts
+++ b/packages/quill/test/unit/formats/list.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/table.spec.ts
+++ b/packages/quill/test/unit/formats/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/modules/history.spec.ts
+++ b/packages/quill/test/unit/modules/history.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { getLastChangeIndex } from '../../../src/modules/history.js';

--- a/packages/quill/test/unit/modules/syntax.spec.ts
+++ b/packages/quill/test/unit/modules/syntax.spec.ts
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import Quill from '../../../src/core.js';
 import Bold from '../../../src/formats/bold.js';

--- a/packages/quill/test/unit/modules/table.spec.ts
+++ b/packages/quill/test/unit/modules/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import Quill from '../../../src/core.js';
 import { describe, expect, test } from 'vitest';
 import { createRegistry } from '../__helpers__/factory.js';

--- a/packages/quill/test/unit/modules/tableEmbed.spec.ts
+++ b/packages/quill/test/unit/modules/tableEmbed.spec.ts
@@ -1,4 +1,4 @@
-import Delta from '@reedsy/quill-delta';
+import { Delta } from '@reedsy/quill-delta';
 import { tableHandler } from '../../../src/modules/tableEmbed.js';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 


### PR DESCRIPTION
This change bumps our version of `@reedsy/quill-delta` through a major bump that removes export defaults.