### PR TITLE
🐛 Patch nbsp issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17256,7 +17256,7 @@
     },
     "packages/quill": {
       "name": "@reedsy/quill",
-      "version": "2.0.3-reedsy-5.0.10",
+      "version": "2.0.3-reedsy-5.0.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reedsy/quill-delta": "^5.1.0-reedsy.4.0.0",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill",
-  "version": "2.0.3-reedsy-5.0.10",
+  "version": "2.0.3-reedsy-5.0.11",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -373,8 +373,7 @@ function convertHTML(
     return blot.html(index, length);
   }
   if (blot instanceof TextBlot) {
-    const escapedText = escapeText(blot.value().slice(index, index + length));
-    return escapedText.replaceAll(' ', '&nbsp;');
+    return escapeText(blot.value().slice(index, index + length));
   }
   if (blot instanceof ParentBlot) {
     // TODO fix API

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1257,17 +1257,17 @@ describe('Editor', () => {
           0,
           11,
         ),
-      ).toEqual('<strong>123&nbsp;</strong>123<em>&nbsp;123</em>');
+      ).toEqual('<strong>123 </strong>123<em> 123</em>');
 
       expect(createEditor(new Delta().insert('1   2\n')).getHTML(0, 5)).toEqual(
-        '1&nbsp;&nbsp;&nbsp;2',
+        '1   2',
       );
 
       expect(
         createEditor(
           new Delta().insert('  123', { bold: true }).insert('\n'),
         ).getHTML(0, 5),
-      ).toEqual('<strong>&nbsp;&nbsp;123</strong>');
+      ).toEqual('<strong>  123</strong>');
     });
 
     test('mixed list', () => {


### PR DESCRIPTION
Fixes:
- https://github.com/reedsy/reedsy-editor/issues/13901

Quill added a replaceAll for spaces to be converted to `&nbsp;`. The consequence for us is that when a user pastes their chapter content elsewhere such as Word, Word has no place to wrap the content since there are no spaces in the sentences, so it simply breaks the words as the only thing left it can do. The user has to literally retype each sentence to fix this, or paste it elsewhere first to revert the `nbsp`s back to spaces.

I propose we revert this change back to how it worked previously, until Quill fixes this upstream and we defer to the fix.

The offending PR: (in a code block since this repo is public)
`https://github.com/slab/quill/pull/4502`

Tested this locally by temp patching my `node_modules` in `reedsy-editor` and confirmed that it worked.